### PR TITLE
slimのgemをinstall

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ gem "tailwindcss-rails"
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 
+gem 'slim-rails'
+
 # Use the database-backed adapters for Rails.cache and Active Job
 gem "solid_cache"
 gem "solid_queue"
@@ -56,4 +58,5 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+  gem 'slim_lint', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,6 +236,7 @@ GEM
     regexp_parser (2.10.0)
     reline (0.6.1)
       io-console (~> 0.5)
+    rexml (3.4.1)
     rubocop (1.76.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -275,6 +276,17 @@ GEM
       rubocop (~> 1.72, >= 1.72.1)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
+    slim (5.2.1)
+      temple (~> 0.10.0)
+      tilt (>= 2.1.0)
+    slim-rails (3.7.0)
+      actionpack (>= 3.1)
+      railties (>= 3.1)
+      slim (>= 3.0, < 6.0, != 5.0.0)
+    slim_lint (0.33.0)
+      rexml (~> 3.2)
+      rubocop (>= 1.0, < 2.0)
+      slim (>= 3.0, < 6.0)
     solid_cache (1.0.7)
       activejob (>= 7.2)
       activerecord (>= 7.2)
@@ -305,11 +317,13 @@ GEM
     tailwindcss-ruby (4.1.8-arm64-darwin)
     tailwindcss-ruby (4.1.8-x86_64-linux-gnu)
     tailwindcss-ruby (4.1.8-x86_64-linux-musl)
+    temple (0.10.3)
     thor (1.3.2)
     thruster (0.1.13)
     thruster (0.1.13-aarch64-linux)
     thruster (0.1.13-arm64-darwin)
     thruster (0.1.13-x86_64-linux)
+    tilt (2.6.0)
     timeout (0.4.3)
     turbo-rails (2.0.16)
       actionpack (>= 7.1.0)
@@ -360,6 +374,8 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rails-omakase
   rubocop-rspec
+  slim-rails
+  slim_lint
   solid_cache
   solid_queue
   stimulus-rails


### PR DESCRIPTION
slimとslim lintのgemを導入した。
erbファイルがすでにある場合は、`gem 'html2slim', github: 'slim-template/html2slim'`をdevelopment環境に入れて変換すること。
[2024年05月現在、html2slimを使う方法](https://zenn.dev/yksn/articles/aff65f3afb73d0)
#39