### PR TITLE
ユーザーがグループから脱退できるようにした

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,4 +1,5 @@
 class DashboardController < ApplicationController
   def index
+    @groups = current_user.groups.preload(:talks)
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -3,11 +3,15 @@ class GroupsController < ApplicationController
 
   # GET /groups or /groups.json
   def index
+    # TODO: 開発のしやすさを考慮し、一時的にall取得にしている。最終は下コードにすること
     @groups = Group.all
+    # @groups = current_user.groups
   end
 
   # GET /groups/1 or /groups/1.json
   def show
+    @memberships = @group.memberships
+    @membership = @memberships.find_by(user: current_user)
   end
 
   # GET /groups/new
@@ -22,6 +26,7 @@ class GroupsController < ApplicationController
   # POST /groups or /groups.json
   def create
     @group = Group.new(group_params)
+    @group.users << current_user
 
     respond_to do |format|
       if @group.save

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class MembershipsController < ApplicationController
+  # TODO:招待制のためURLを作成するようになる
+  def create
+  end
+
+  def destroy
+    membership = current_user.memberships.find_by!(group_id: params[:group_id])
+    membership.destroy!
+
+    redirect_to dashboard_path, status: :see_other, notice: 'xxxグループから抜けました。もういちど参加する場合はメンバーに招待URLを発行してもらってください。'
+  end
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,7 +1,7 @@
 class Group < ApplicationRecord
   has_many :talks
   has_many :memberships, dependent: :destroy
-  has_many :users, through: :group_memberships
+  has_many :users, through: :memberships
 
   validates :name, presence: true, length: { maximum: 100 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   has_many :comments
   has_many :subscriptions
   has_many :memberships, dependent: :destroy
-  has_many :groups, through: :group_memberships
+  has_many :groups, through: :memberships
 
   class << self
     def find_or_create_from_auth_hash(auth_hash)

--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -1,3 +1,4 @@
+p style="color: green" = notice
 - if @groups.size == 0
   | まだ所属グループがありません！<br>
   | グループを作成し、他のユーザーを招待してみましょう。<br>

--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -1,4 +1,17 @@
-h1 Dashboard#index
-p ログイン後ルート画面
+- if @groups.size == 0
+  | まだ所属グループがありません！<br>
+  | グループを作成し、他のユーザーを招待してみましょう。<br>
+  |
+  |グループに招待されていますか？<br>
+  |招待されたページでグループに参加してください。<br>
+
+- elsif @groups.size == 1
+  - group = @groups.first
+  = render template: 'talks/index', talks: group.talks
+
+- else
+  - @groups.each do |group|
+    = link_to "#{group.name}", group
+    p
 
 = link_to 'グループ一覧', groups_path

--- a/app/views/groups/_group.html.slim
+++ b/app/views/groups/_group.html.slim
@@ -1,6 +1,6 @@
 div id="#{dom_id group}"
-  p
-  = group.name
+  .text-2xl
+    = group.name
   - group.users.each do |user|
      div
        = user.name

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -2,9 +2,13 @@ p style="color: green" = notice
 
 == render @group
 
+= link_to 'グループのトーク一覧へ行く', group_talks_path(@group)
+
 div
   => link_to 'グループ名を編集する', edit_group_path(@group)
   '|
   =< link_to 'グループ一覧へ戻る', groups_path
 
+  - if @membership.present?
+    = button_to 'グループから抜ける', group_membership_path(@group, @membership), { method: :delete, data: { turbo_confirm: 'グループを抜けると、再参加する場合は招待してもらう必要があります。本当に抜けますか？'}}
   = button_to 'グループを削除する', @group, method: :delete

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -25,5 +25,6 @@ html
         = current_user.name
         | さん
         = link_to 'ログアウト', log_out_path
+        = link_to 'トップへ戻る', dashboard_path
     main.container.mx-auto.mt-28.px-5
       = yield

--- a/app/views/talks/index.html.slim
+++ b/app/views/talks/index.html.slim
@@ -2,10 +2,11 @@ p style="color: green" = notice
 
 h1 Talks
 
-#talks
-  - @talks.each do |talk|
-    == render talk
-    p
-      = link_to "Show this talk", talk
+/ #TODO Talks画面の作成
+/ #talks
+/   - @talks.each do |talk|
+/     == render talk
+/     p
+/       = link_to "Show this talk", talk
 
-= link_to "New talk", new_talk_path
+/ = link_to "New talk", new_talk_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
     resources :talks do
       resources :comments, only: %i[create update destroy]
     end
+    resources :memberships, only: %i[create destroy]
   end
   resources :invitations, only: %i[show create update destroy] 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_05_060214) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_22_073809) do
   create_table "brailles", force: :cascade do |t|
     t.text "original_text", null: false
     t.text "raised_braille", null: false
@@ -34,15 +34,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_05_060214) do
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
-  create_table "group_memberships", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.integer "group_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["group_id"], name: "index_group_memberships_on_group_id"
-    t.index ["user_id"], name: "index_group_memberships_on_user_id"
-  end
-
   create_table "groups", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -59,6 +50,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_05_060214) do
     t.index ["group_id"], name: "index_invitations_on_group_id"
     t.index ["token"], name: "index_invitations_on_token", unique: true
     t.index ["user_id"], name: "index_invitations_on_user_id"
+  end
+
+  create_table "memberships", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "group_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_memberships_on_group_id"
+    t.index ["user_id"], name: "index_memberships_on_user_id"
   end
 
   create_table "notifications", force: :cascade do |t|
@@ -107,10 +107,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_05_060214) do
   add_foreign_key "brailles", "users"
   add_foreign_key "comments", "talks"
   add_foreign_key "comments", "users"
-  add_foreign_key "group_memberships", "groups"
-  add_foreign_key "group_memberships", "users"
   add_foreign_key "invitations", "groups"
   add_foreign_key "invitations", "users"
+  add_foreign_key "memberships", "groups"
+  add_foreign_key "memberships", "users"
   add_foreign_key "notifications", "users"
   add_foreign_key "subscriptions", "talks"
   add_foreign_key "subscriptions", "users"


### PR DESCRIPTION
ユーザーがグループから脱退できるようにした。
グループ作成、削除、名前編集は現状誰でもできる状態なので、別のPRで対象を制限する予定。

- #88 