### PR TITLE
tailwind v4へのdependabotを無効化する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,19 @@
 version: 2
 updates:
-- package-ecosystem: bundler
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    ignore:
+      # tailwind v4とkamalでデプロイ先にCSSが反映されない不具合があるため、v4を一時的に除外
+      - dependency-name: "tailwindcss-ruby"
+        versions: ["~> 4.0"]
+      - dependency-name: "tailwindcss-rails"
+        versions: ["~> 4.0"]
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10


### PR DESCRIPTION
tailwind v4とkamalでデプロイ先にCSSが反映されない不具合があるため、v4を一時的に除外する