### PR TITLE
最新ブラウザに限定する必要性が薄いので、allow_browserを削除

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,4 @@
 class ApplicationController < ActionController::Base
-  # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  allow_browser versions: :modern
-
   before_action :authenticate, :set_unread_notifications
   helper_method :logged_in?, :current_user
 


### PR DESCRIPTION
- `allow_browser versions: :modern` による最新ブラウザに限定する機能を削除