### PR TITLE
退会ユーザーを物理削除から論理削除に変更した際に、対応できていなかった部分を修正

### DIFF
--- a/app/forms/comment_braille_form.rb
+++ b/app/forms/comment_braille_form.rb
@@ -32,7 +32,7 @@ class CommentBrailleForm
       )
 
       Subscription.find_or_create_by!(user: @user, talk: @talk)
-      subscribers = @talk.subscribers.where.not(id: @user.id)
+      subscribers = @talk.subscribers.active.where.not(id: @user.id)
       subscribers.each do |subscriber|
         Notification.find_or_create_by!(
           user: subscriber,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,8 @@ class User < ApplicationRecord
 
   validates :nickname, format: { without: /\A\s*\z/, message: 'を入力してください' }, allow_nil: true
 
+  scope :active, -> { where(deleted_at: nil) }
+
   def display_name
     nickname.presence || name
   end


### PR DESCRIPTION
- ` dependent: :destroy`の記述を削除（ https://github.com/ayu-0505/TenjiGroupTalk/pull/374/commits/36a110d273f19a440e5947429933e11965658df2 ）
-  通知作成の際に退会ユーザーを含めないように通知対象者にactiveかどうかのscopeを追加（ https://github.com/ayu-0505/TenjiGroupTalk/pull/374/commits/0bcae7f91c79a95334dcd86e160cf8c77f49ea20 ）

当初は物理削除の方針であり、そのまま残っていた記述や不備を修正しました。
退会ユーザーへの通知が作成されていないかはテストでチェックすべきとは思いますが、 以下を対応する際に、まとめて追加しようと思います。
- #370