### PR TITLE
モバイルブラウザ利用者向けの誘導コード部分に、理由コメントを追加

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,6 +4,9 @@ class HomeController < ApplicationController
 
   def index
     redirect_to dashboard_path if current_user.present?
+
+    # NOTE: Googleログインはモバイルアプリ用ブラウザでは利用できない。
+    # そのため、モバイルアプリブラウザ（主要なもののみ対応）の場合は、外部ブラウザ利用を促すページに誘導する
     ua = request.user_agent.to_s.downcase
     is_mobile = ua.include?('mobile') || ua.include?('iphone') || ua.include?('android')
     is_web_view = ua.include?('line') || ua.include?('instagram') || ua.include?('fb')


### PR DESCRIPTION
Googleログインはモバイルアプリ用ブラウザでは利用できない。
しかも、Google側の出すエラーメッセージでは、アプリブラウザが原因であることがユーザーに伝わりにくい。
そのため、モバイルアプリブラウザ（主要なもののみ対応）の場合は、外部ブラウザ利用を促すページに誘導している。
コードのみでは理由が分かりにくいため、追加でコメントを付与する。