### PR TITLE
dependabotでrailsを除外

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: daily
     open-pull-requests-limit: 10
     ignore:
+      - dependency-name: "rails"
+
       # tailwind v4とkamalでデプロイ先にCSSが反映されない不具合があるため、v4を一時的に除外
       - dependency-name: "tailwindcss-ruby"
         versions: ["~> 4.0"]


### PR DESCRIPTION
Railsは手動更新が望ましいので、dependabotの自動更新対象から除外する。