### PR TITLE
ログイン後の利用規約とプライバシーポリシーにおける500エラーの解消

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,9 @@ class ApplicationController < ActionController::Base
   end
 
   def set_unread_notifications
+    @unread_notifications = Notification.none
+    return unless logged_in?
+
     @unread_notifications = current_user.notifications.unread.preload(comment: [ :talk, :user ]).order(created_at: :desc)
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,5 @@
 class HomeController < ApplicationController
   skip_before_action :authenticate, only: %i[index welcome login_prompt terms privacy]
-  skip_before_action :set_unread_notifications, only: %i[index welcome login_prompt terms privacy]
 
   def index
     redirect_to dashboard_path if current_user.present?


### PR DESCRIPTION
原因はヘッダーの通知部分の表示判定`if @unread_notifications.size > 0`で、変数`@unread_notifications`がnilだったことによるもの。
`@unread_notifications`をセットする`set_unread_notifications`がtermsとprivacyでskipされていたため、判定があるログイン後のみ発生していた。
`set_unread_notifications`を変更し、skipを削除した。