### PR TITLE
rubocop-capybaraの指摘事項変更に伴い、have_(no)_contentをhave_(no)_textに変更

### DIFF
--- a/spec/system/comments_spec.rb
+++ b/spec/system/comments_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe "Comments", type: :system do
       visit group_talk_path(group, talk)
       fill_in 'コメント内容', with: '面白そう！'
       click_on 'コメントを投稿する'
-      expect(page).to have_content('面白そう！')
-      expect(page).to have_content("コメント （#{talk.reload.comments.size}）")
+      expect(page).to have_text('面白そう！')
+      expect(page).to have_text("コメント （#{talk.reload.comments.size}）")
     end
   end
 
@@ -41,8 +41,8 @@ RSpec.describe "Comments", type: :system do
         fill_in 'コメント内容', with: '新規コメント', match: :first
         click_on 'コメントを更新する', match: :first
       end
-      expect(page).to have_content('新規コメント')
-      expect(page).to have_no_content(comments[0].description)
+      expect(page).to have_text('新規コメント')
+      expect(page).to have_no_text(comments[0].description)
     end
   end
 
@@ -56,9 +56,9 @@ RSpec.describe "Comments", type: :system do
           click_on '削除する', match: :first
         end
       end
-      expect(page).to have_content(comments[0].description)
-      expect(page).to have_no_content(comments[1].description)
-      expect(page).to have_content("コメント （#{talk.reload.comments.size}）")
+      expect(page).to have_text(comments[0].description)
+      expect(page).to have_no_text(comments[1].description)
+      expect(page).to have_text("コメント （#{talk.reload.comments.size}）")
     end
   end
 
@@ -118,12 +118,12 @@ RSpec.describe "Comments", type: :system do
       visit group_talk_path(group, talk)
 
       within "#comment_#{comments[0].id}" do
-        expect(page).to have_content ("#{braille.raised_braille}")
-        expect(page).to have_content ("#{braille.indented_braille}")
+        expect(page).to have_text ("#{braille.raised_braille}")
+        expect(page).to have_text ("#{braille.indented_braille}")
         expect(page).to have_css('.comment_original_text.hidden', visible: :all)
 
         click_on '正解を見る'
-        expect(page).to have_content ("#{braille.original_text}")
+        expect(page).to have_text ("#{braille.original_text}")
       end
     end
 
@@ -133,7 +133,7 @@ RSpec.describe "Comments", type: :system do
       visit group_talk_path(group, talk)
       within "#comment_#{comments[0].id}" do
         click_on '正解を見る'
-        expect(page).to have_content '正解をかくす'
+        expect(page).to have_text '正解をかくす'
         click_on '正解をかくす'
         expect(page).to have_css('.comment_original_text.hidden', visible: :all)
       end
@@ -151,18 +151,18 @@ RSpec.describe "Comments", type: :system do
       recent_comments = remaining_comments.slice!(-count, count)
       hidden_comments = remaining_comments
 
-      expect(page).to have_content "コメント （#{all_comments.size}）"
+      expect(page).to have_text "コメント （#{all_comments.size}）"
       expect(page).to have_css('[data-comments-pagination-target="remainingCount"]', text: hidden_comments.size)
-      expect(page).to have_content('件のコメントを省略中')
-      expect(page).to have_content 'コメントをさらに表示'
+      expect(page).to have_text('件のコメントを省略中')
+      expect(page).to have_text 'コメントをさらに表示'
       initial_comments.each do |comment|
-        expect(page).to have_content(comment.description)
+        expect(page).to have_text(comment.description)
       end
       hidden_comments.each do |comment|
-        expect(page).to have_no_content(comment.description)
+        expect(page).to have_no_text(comment.description)
       end
       recent_comments.each do |comment|
-        expect(page).to have_content(comment.description)
+        expect(page).to have_text(comment.description)
       end
     end
 
@@ -181,14 +181,14 @@ RSpec.describe "Comments", type: :system do
         return if hidden_count <= 0
 
         expect(page).to have_css('[data-comments-pagination-target="remainingCount"]', text: hidden_count)
-        expect(page).to have_content('件のコメントを省略中')
+        expect(page).to have_text('件のコメントを省略中')
         click_on 'コメントをさらに表示'
         next_comments.each do |comment|
-          expect(page).to have_content(comment.description)
+          expect(page).to have_text(comment.description)
         end
         hidden_count -= Comment::INCREMENT_SIZE
       end
-      expect(page).to have_no_content('コメントをさらに表示')
+      expect(page).to have_no_text('コメントをさらに表示')
     end
   end
 end

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe 'Dashboard', type: :system do
 
       visit root_path
       find_by_id('notification-menu').click
-      expect(page).to have_content("#{talk.title}に#{comment.user.nickname}よりコメントがありました")
+      expect(page).to have_text("#{talk.title}に#{comment.user.nickname}よりコメントがありました")
       click_on "#{talk.title}に#{comment.user.nickname}よりコメントがありました"
-      expect(page).to have_content(talk.description)
+      expect(page).to have_text(talk.description)
       find_by_id('notification-menu').click
-      expect(page).to have_no_content("#{talk.title}に#{comment.user.nickname}よりコメントがありました")
+      expect(page).to have_no_text("#{talk.title}に#{comment.user.nickname}よりコメントがありました")
     end
   end
 

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe "Groups", type: :system do
     context 'when a non-member user accesses' do
       it 'is prevented' do
         visit group_path(group)
-        expect(page).to have_content 'この操作を行うには、グループのメンバーである必要があります'
+        expect(page).to have_text 'この操作を行うには、グループのメンバーである必要があります'
 
         visit edit_group_path(group)
-        expect(page).to have_content 'この操作を行うには、グループのメンバーである必要があります'
+        expect(page).to have_text 'この操作を行うには、グループのメンバーである必要があります'
       end
     end
   end
@@ -28,9 +28,9 @@ RSpec.describe "Groups", type: :system do
 
       log_in_as user
       visit group_path(group)
-      expect(page).to have_content(user.display_name)
+      expect(page).to have_text(user.display_name)
       members.each do |member|
-        expect(page).to have_content(member.display_name)
+        expect(page).to have_text(member.display_name)
       end
     end
 
@@ -43,20 +43,20 @@ RSpec.describe "Groups", type: :system do
       it 'prevents the user from leaving the group' do
         visit group_path(group)
         click_button 'グループから抜ける'
-        expect(page).to have_content '管理者はグループを抜けられません。グループ削除を行なってください。'
+        expect(page).to have_text '管理者はグループを抜けられません。グループ削除を行なってください。'
       end
 
       it 'creates an invitation URL when the create button is clicked' do
         visit group_path(group)
         click_button 'メッセージを作成'
-        expect(page).to have_content "http://www.example.com/welcome?invitation_token=#{Invitation.last.token}"
+        expect(page).to have_text "http://www.example.com/welcome?invitation_token=#{Invitation.last.token}"
       end
 
       it 'deletes the group when the user confirms deletion', :js do
         visit group_path(group)
         click_button 'グループを削除する'
         expect(page.accept_confirm).to eq 'グループを削除すると今までのトークとコメントのデータが全て削除されます。この操作は元に戻すことができません。本当によろしいですか？'
-        expect(page).to have_content 'グループを削除しました'
+        expect(page).to have_text 'グループを削除しました'
         expect(Group.all.include?(group)).to be false
       end
 

--- a/spec/system/talks_spec.rb
+++ b/spec/system/talks_spec.rb
@@ -36,10 +36,10 @@ RSpec.describe 'Talks', type: :system do
 
       it 'does not display the edit and delete links' do
         visit group_talk_path(group, talks[0])
-        expect(page).to have_content(talks[0].title)
+        expect(page).to have_text(talks[0].title)
         within('.talk') do
-          expect(page).to have_no_content('編集する')
-          expect(page).to have_no_content('削除する')
+          expect(page).to have_no_text('編集する')
+          expect(page).to have_no_text('削除する')
         end
       end
     end
@@ -52,7 +52,7 @@ RSpec.describe 'Talks', type: :system do
         expect(span[:class]).to include('bg-sky-300')
         expect(span[:class]).to include('left-0.5')
         find('label[for="subscription_check"]').click
-        expect(page).to have_content '通知登録しました'
+        expect(page).to have_text '通知登録しました'
         expect(span[:class]).to include('bg-sky-600')
         expect(span[:class]).to include('left-5')
 
@@ -71,7 +71,7 @@ RSpec.describe 'Talks', type: :system do
         expect(span[:class]).to include('bg-sky-600')
         expect(span[:class]).to include('left-5')
         find('label[for="subscription_check"]').click
-        expect(page).to have_content '通知登録を解除しました'
+        expect(page).to have_text '通知登録を解除しました'
 
         expect(Subscription.find_by(id: subscription_id)).to be_nil
         expect(span[:class]).to include('bg-sky-300')
@@ -88,9 +88,9 @@ RSpec.describe 'Talks', type: :system do
       fill_in '内容', with: '点字を使ってしりとりしましょう'
       expect(page).to have_button('トークを作成する', disabled: false)
       click_on 'トークを作成する'
-      expect(page).to have_content('トークが作成されました！')
-      expect(page).to have_content('点字しりとり！')
-      expect(page).to have_content('点字を使ってしりとりしましょう')
+      expect(page).to have_text('トークが作成されました！')
+      expect(page).to have_text('点字しりとり！')
+      expect(page).to have_text('点字を使ってしりとりしましょう')
     end
   end
 
@@ -104,11 +104,11 @@ RSpec.describe 'Talks', type: :system do
       fill_in '内容', with: 'これは新しいトークです！'
       expect(page).to have_button('トークを更新する', disabled: false)
       click_on 'トークを更新する'
-      expect(page).to have_content('トークを更新しました！')
-      expect(page).to have_no_content(talks[0].title)
-      expect(page).to have_no_content(talks[0].description)
-      expect(page).to have_content('新規トーク')
-      expect(page).to have_content('これは新しいトークです！')
+      expect(page).to have_text('トークを更新しました！')
+      expect(page).to have_no_text(talks[0].title)
+      expect(page).to have_no_text(talks[0].description)
+      expect(page).to have_text('新規トーク')
+      expect(page).to have_text('これは新しいトークです！')
     end
   end
 
@@ -122,8 +122,8 @@ RSpec.describe 'Talks', type: :system do
           click_on '削除する'
         end
       end
-      expect(page).to have_content('トークは削除されました')
-      expect(page).to have_no_content(talks[0].title)
+      expect(page).to have_text('トークは削除されました')
+      expect(page).to have_no_text(talks[0].title)
     end
   end
 
@@ -160,19 +160,19 @@ RSpec.describe 'Talks', type: :system do
 
     it 'can reveal the correct hiragana for the braille quiz', :js do
       within '#talk_braille' do
-        expect(page).to have_content ("#{Braille.last.raised_braille}")
-        expect(page).to have_content ("#{Braille.last.indented_braille}")
+        expect(page).to have_text ("#{Braille.last.raised_braille}")
+        expect(page).to have_text ("#{Braille.last.indented_braille}")
         expect(page).to have_css('.talk_original_text.hidden', visible: :all)
 
         click_on '正解を見る'
-        expect(page).to have_content ("#{Braille.last.original_text}")
+        expect(page).to have_text ("#{Braille.last.original_text}")
       end
     end
 
     it 'hides the correct hiragana when the button is pressed', :js do
       within '#talk_braille' do
         click_on '正解を見る'
-        expect(page).to have_content '正解をかくす'
+        expect(page).to have_text '正解をかくす'
         click_on '正解をかくす'
         expect(page).to have_css('.talk_original_text.hidden', visible: :all)
       end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe 'Users', type: :system do
   describe 'show the user' do
     it 'displays the user' do
       visit user_path(user)
-      expect(page).to have_content user.display_name
+      expect(page).to have_text user.display_name
       user.groups.each do |group|
-        expect(page).to have_content group.name
+        expect(page).to have_text group.name
       end
     end
   end
@@ -25,7 +25,7 @@ RSpec.describe 'Users', type: :system do
       click_on 'ネームを変更する'
       fill_in 'ネームを入力してください', with: '新しいニックネーム'
       click_on 'ネームを更新する'
-      expect(page).to have_content '新しいニックネーム'
+      expect(page).to have_text '新しいニックネーム'
     end
 
     it 'does not save when nickname is blank', :js do
@@ -33,9 +33,9 @@ RSpec.describe 'Users', type: :system do
       click_on 'ネームを変更する'
       fill_in 'user_nickname', with: '       '
       expect(page).to have_button('ネームを更新する', disabled: true)
-      expect(page).to have_content 'ネームを変更する'
+      expect(page).to have_text 'ネームを変更する'
       click_on 'プロフィールへ戻る'
-      expect(page).to have_content user.display_name
+      expect(page).to have_text user.display_name
     end
   end
 end


### PR DESCRIPTION
rubocop-capybaraの指摘事項に、have_(no)_contentよりhave_(no)_text推奨が追加されたので、該当部分を変更