### PR TITLE
formオブジェクトにおけるSubscriptionとNotificationのデータ確認テストを追加

### DIFF
--- a/spec/forms/comment_braille_form_spec.rb
+++ b/spec/forms/comment_braille_form_spec.rb
@@ -46,6 +46,29 @@ RSpec.describe CommentBrailleForm, type: :model do
         expect(form.comment.braille).to be_nil
       end
     end
+
+    context 'when the talk has subscribers' do
+      let(:subscriber) { create(:user) }
+      let(:inactive_subscriber) { create(:user, deleted_at: Time.current) }
+      let(:form) { described_class.new(user:, talk:, attributes: { description: 'test description' }) }
+
+      before do
+        create(:subscription, user: subscriber, talk:)
+        create(:subscription, user: inactive_subscriber, talk:)
+      end
+
+      it 'creates a subscription for the commenter and a notification for each active subscriber' do
+        expect {
+          expect(form.save).to be true
+        }.to change(Subscription, :count).by(1)
+          .and change(Notification, :count).by(1)
+
+        expect(Subscription.find_by(user:, talk:)).to be_present
+        expect(Notification.find_by(user: subscriber, comment: form.comment)).to be_present
+        expect(Notification.find_by(user:, comment: form.comment)).to be_nil
+        expect(Notification.find_by(user: inactive_subscriber, comment: form.comment)).to be_nil
+      end
+    end
   end
 
   describe '#update' do

--- a/spec/forms/talk_braille_form_spec.rb
+++ b/spec/forms/talk_braille_form_spec.rb
@@ -47,6 +47,18 @@ RSpec.describe TalkBrailleForm, type: :model do
         expect(form.talk.braille).to be_nil
       end
     end
+
+    context 'when a talk is created' do
+      it 'creates a subscription for the user who created the talk' do
+        form = described_class.new(user:, group:, attributes: { title: 'test', description: 'test description' })
+
+        expect {
+          expect(form.save).to be true
+        }.to change(Subscription, :count).by(1)
+
+        expect(Subscription.find_by(user:, talk: form.talk)).to be_present
+      end
+    end
   end
 
   describe '#update' do


### PR DESCRIPTION
#  該当issue
- #370  

# 内容
以下の内容のテストを追加。
- Talk
  - Talk作成者にSubscriptionが作成されるか
- Comment
  - Comment作成者にSubscriptionが作成されるか
  - そのTalkのサブスク登録者当てにNotificationが作成されるか
  - その際に、Comment作成者は通知の対象から外れるか
  - 同じく、退会ユーザーは通知の対象から外れるか